### PR TITLE
feature: bulk insert example and excel read

### DIFF
--- a/bulk.sql
+++ b/bulk.sql
@@ -1,0 +1,3 @@
+BULK INSERT dbo.auth
+FROM '/home/linux/Desktop/MSSQL/test.csv'
+WITH ( CODEPAGE='RAW', FIRSTROW=2, FORMAT='CSV');

--- a/testing.py
+++ b/testing.py
@@ -1,0 +1,26 @@
+import pandas
+
+xlsx = pandas.ExcelFile( "跨波次變項對照表_加入構面.xlsx")
+
+parent = pandas.read_excel( xlsx, sheet_name=0)
+
+teacher = pandas.read_excel( xlsx, sheet_name=1)
+
+friend = pandas.read_excel( xlsx, sheet_name=2)
+
+df = parent.append([ teacher, friend])
+
+columns_to_keep = ['構面', 'min_auth']
+
+# get the unique ones
+df = df.drop_duplicates(subset=['構面'])
+
+df['min_auth'] = 4
+
+df = df.reset_index(drop=True)
+
+# print(df.drop_duplicates(subset=columns_to_keep))
+
+df.loc[:, columns_to_keep].to_csv( "test.csv")
+
+xlsx.close()


### PR DESCRIPTION
bulk insert:
	CODEPAGE is the inserting format that is read.
	It is set to 'RAW' here since most of it is not supported on Linux.
	Note: the file path seems to be absolute.

testing:
	It will strip the unique classes out of the xlsx file and format it
	so that it can be bulk inserted.
Some things to be conserned: Will bulk insert accept autoincrement?